### PR TITLE
Update the rdkit implementation for getting the fingerprints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lohi_splitter"
-version = "1.0"
+version = "1.1"
 authors = [
   { name="Simon Steshin", email="simon.steshin@gmail.com" },
 ]
@@ -19,7 +19,7 @@ classifiers = [
 dependencies = [
     "mip==1.15.0",
     "tqdm",
-    "rdkit-pypi",
+    "rdkit-pypi>=2022.09.1",
     "networkx",
     "numpy",
 ]

--- a/src/lohi_splitter/lo_splitter.py
+++ b/src/lohi_splitter/lo_splitter.py
@@ -1,5 +1,6 @@
 from rdkit import Chem, DataStructs
 from rdkit.Chem import AllChem
+from rdkit.Chem import rdFingerprintGenerator
 import numpy as np
 from .utils import get_similar_mols
 
@@ -12,10 +13,11 @@ def select_distinct_clusters(
     """
 
     clusters = []
+    fp_generator = rdFingerprintGenerator.GetMorganGenerator(radius=2, fpSize=1024)
 
     while len(clusters) < max_clusters:
         mols = [Chem.MolFromSmiles(smile) for smile in smiles]
-        all_fps = [AllChem.GetMorganFingerprintAsBitVect(x, 2, 1024) for x in mols]
+        all_fps = [fp_generator.GetFingerprint(x) for x in mols]
         total_neighbours = []
         stds = []
 

--- a/src/lohi_splitter/min_vertex_k_cut.py
+++ b/src/lohi_splitter/min_vertex_k_cut.py
@@ -3,6 +3,7 @@ import numpy as np
 
 from rdkit import Chem, DataStructs
 from rdkit.Chem import AllChem
+from rdkit.Chem import rdFingerprintGenerator
 import mip
 
 
@@ -21,8 +22,10 @@ def get_neighborhood_graph(smiles, threshold):
     Returns:
         G -- neighborhood graph (nx.Graph())
     """
+    fp_generator = rdFingerprintGenerator.GetMorganGenerator(radius=2, fpSize=1024)
+
     mols = [Chem.MolFromSmiles(smile) for smile in smiles]
-    fps = [AllChem.GetMorganFingerprintAsBitVect(x, 2, 1024) for x in mols]
+    fps = [fp_generator.GetFingerprint(x) for x in mols]
 
     similarity_matrix = []
     for fp in fps:

--- a/src/lohi_splitter/utils.py
+++ b/src/lohi_splitter/utils.py
@@ -1,5 +1,6 @@
 from rdkit import Chem, DataStructs
 from rdkit.Chem import AllChem
+from rdkit.Chem import rdFingerprintGenerator
 import numpy as np
 
 
@@ -19,15 +20,17 @@ def get_similar_mols(lhs, rhs, return_idx=False):
             (nearest_sim, nearest_idx)
             nearest_idx -- list of length of lhs. i'th element contains idx of rhs molecule, which is similar to lhs[i]
     """
+    fp_generator = rdFingerprintGenerator.GetMorganGenerator(radius=2, fpSize=1024)
+
     lhs_mols = []
     for smiles in lhs:
         lhs_mols.append(Chem.MolFromSmiles(smiles))
-    lhs_fps = [AllChem.GetMorganFingerprintAsBitVect(x, 2, 1024) for x in lhs_mols]
+    lhs_fps = [fp_generator.GetFingerprint(x) for x in lhs_mols]
 
     rhs_mols = []
     for smiles in rhs:
         rhs_mols.append(Chem.MolFromSmiles(smiles))
-    rhs_fps = [AllChem.GetMorganFingerprintAsBitVect(x, 2, 1024) for x in rhs_mols]
+    rhs_fps = [fp_generator.GetFingerprint(x) for x in rhs_mols]
 
     nearest_sim = []
     nearest_idx = []


### PR DESCRIPTION
AllChem.GetMorganFingerprint is deprecated in the most recent version of rdkit and returns a warning that is painful to the eyes, so updated the newer implementation