### PR TITLE
Memory-efficient Lo split algorithm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lohi_splitter"
-version = "1.1"
+version = "1.2"
 authors = [
   { name="Simon Steshin", email="simon.steshin@gmail.com" },
 ]

--- a/src/lohi_splitter/lo_splitter.py
+++ b/src/lohi_splitter/lo_splitter.py
@@ -3,74 +3,98 @@ from rdkit.Chem import AllChem
 from rdkit.Chem import rdFingerprintGenerator
 import numpy as np
 from .utils import get_similar_mols
+from tqdm import tqdm
+from scipy.sparse import csr_matrix
+
+
+def construct_similarity_matrix(smiles, threshold, verbose=False):
+    """
+    Construct a similarity matrix for a given list of SMILES.
+    """
+    fp_generator = rdFingerprintGenerator.GetMorganGenerator(radius=2, fpSize=1024)
+
+    # Convert SMILES to fingerprints
+    mols = [Chem.MolFromSmiles(smile) for smile in smiles]
+    mols_iter = tqdm(mols, desc="Generating fingerprints") if verbose else mols
+
+    all_fps = [fp_generator.GetFingerprint(mol) for mol in mols_iter]
+    num_mols = len(all_fps)
+
+    # Store only values above threshold to optimize memory usage
+    rows, cols, data = [], [], []
+    all_fps_iter = tqdm(all_fps, desc="Computing pairwise similarities") if verbose else all_fps
+
+    for i, fp in enumerate(all_fps_iter):
+        sims = DataStructs.BulkTanimotoSimilarity(fp, all_fps)
+        valid_idx = np.where(np.array(sims) > threshold)[0]
+
+        rows.extend([i] * len(valid_idx))
+        cols.extend(valid_idx)
+        data.extend(sims[j] for j in valid_idx)
+
+    # CSR: Compressed Sparse Row format
+    similarity_matrix = csr_matrix((data, (rows, cols)), shape=(num_mols, num_mols))
+    return similarity_matrix
+
 
 
 def select_distinct_clusters(
-    smiles, threshold, min_cluster_size, max_clusters, values, std_threshold
+    smiles, threshold, min_cluster_size, max_clusters, values, std_threshold, verbose=False
 ):
     """
     A greedy algorithm to select independent clusters from datasets. A part of the Lo splitter.
     """
-
     clusters = []
-    fp_generator = rdFingerprintGenerator.GetMorganGenerator(radius=2, fpSize=1024)
+    num_mols = len(smiles)
+    similarity_matrix = construct_similarity_matrix(smiles, threshold, verbose=verbose)
 
     while len(clusters) < max_clusters:
-        mols = [Chem.MolFromSmiles(smile) for smile in smiles]
-        all_fps = [fp_generator.GetFingerprint(x) for x in mols]
-        total_neighbours = []
-        stds = []
+        if verbose:
+            print(f"Clusters: {len(clusters)}/{max_clusters}")
 
-        for fps in all_fps:
-            sims = DataStructs.BulkTanimotoSimilarity(fps, all_fps)
-            neighbors_idx = np.array(sims) > threshold
-            total_neighbours.append(neighbors_idx.sum())
-            stds.append(values[neighbors_idx].std())
+        # Compute neighbor counts and compute std deviations
+        total_neighbours = np.array(similarity_matrix.getnnz(axis=1))
+        stds = np.array([values[similarity_matrix[i].indices].std() if total_neighbours[i] > 0 else 0 
+                         for i in range(num_mols)])
 
-        total_neighbours = np.array(total_neighbours)
-        stds = np.array(stds)
+        # Select valid clusters indices for iteration
+        valid_neighbours_idx = np.where(total_neighbours > min_cluster_size)[0]
+        valid_stds_idx = np.where(stds > std_threshold)[0]
+        valid_idx = np.intersect1d(valid_neighbours_idx, valid_stds_idx)
 
-        # Find the most distant cluster
+        # Find the most distant cluster considering cluster size and std deviation
         central_idx = None
         least_neighbours = max(total_neighbours)
-        for idx, n_neighbours in enumerate(total_neighbours):
-            if n_neighbours > min_cluster_size:
-                if n_neighbours < least_neighbours:
-                    if stds[idx] > std_threshold:
-                        least_neighbours = n_neighbours
-                        central_idx = idx
+        for idx in valid_idx:
+            n_neighbours = total_neighbours[idx]
+            if n_neighbours >= least_neighbours:
+                continue
+            least_neighbours, central_idx = n_neighbours, idx
 
-        if central_idx is None:
-            break  # there are no clusters
+        if (central_idx is None) or (valid_idx.size == 0):
+            break  # There are no clusters
 
-        sims = DataStructs.BulkTanimotoSimilarity(all_fps[central_idx], all_fps)
-        is_neighbour = np.array(sims) > threshold
+        # Get cluster members
+        is_neighbour = similarity_matrix[central_idx].indices
 
-        # Add them into cluster
-        cluster_smiles = []
-        for idx, value in enumerate(is_neighbour):
-            if value:
-                if (
-                    idx != central_idx
-                ):  # we add the central molecule at the end of the list
-                    cluster_smiles.append(smiles[idx])
-        cluster_smiles.append(smiles[central_idx])
-        clusters.append(cluster_smiles)
+        # Remove central_idx from cluster and append to the end
+        is_neighbour = is_neighbour[is_neighbour != central_idx]
+        cluster_smiles = np.append(smiles[is_neighbour], smiles[central_idx])
+        clusters.append(cluster_smiles.tolist())
 
-        # Remove neighbours of neighbours from the rest of smiles
+        # Remove neighbors of neighbors from the rest of smiles
         nearest_sim = get_similar_mols(smiles, cluster_smiles)
-        rest_idx = []
-        for idx, dist in enumerate(nearest_sim):
-            if dist < threshold:
-                rest_idx.append(idx)
-        smiles = smiles[rest_idx]
-        values = values[rest_idx]
+        keep_mask = np.where(nearest_sim < threshold)[0]
+
+        smiles, values = smiles[keep_mask], values[keep_mask]
+        similarity_matrix = similarity_matrix[np.ix_(keep_mask, keep_mask)]
+        num_mols = len(smiles)
 
     return clusters, smiles
 
 
 def lo_train_test_split(
-    smiles, threshold, min_cluster_size, max_clusters, values, std_threshold
+    smiles, threshold, min_cluster_size, max_clusters, values, std_threshold, verbose=False
 ):
     """
     Lo splitter. Refer to tutorial 02_lo_split.ipynb and the paper by Simon Steshin titled "Lo-Hi: Practical ML Drug Discovery Benchmark", 2023.
@@ -95,7 +119,8 @@ def lo_train_test_split(
         values = np.array(values)
 
     cluster_smiles, train_smiles = select_distinct_clusters(
-        smiles, threshold, min_cluster_size, max_clusters, values, std_threshold
+        smiles, threshold, min_cluster_size, max_clusters, 
+        values, std_threshold, verbose=verbose
     )
     train_smiles = list(train_smiles)
     # Move one molecule from each test cluster to the training set


### PR DESCRIPTION
I was using the Lo splitter for a QSAR modeling project with a larger dataset (600k+ molecules) and ran into issues with memory usage. After digging into the code, I found a few areas that could be optimized. Here’s what I changed:

- Moved the fingerprint and similarity calculations outside the clustering loop.
- Stored only the similarities above a threshold using a CSR (Compressed Sparse Row) matrix to save memory.
- Reduced the dataset size step by step during clustering.
- Replaced some loops with NumPy vectorized operations.

The original code would have needed around 1.37 TiB of RAM just to store the similarity matrix (using 32-bit floats). With these changes, I was able to run everything on regular hardware without problems.

**Performance improvements**
When running the example notebook, this implementation reduced execution time while still returning the same clusters for the input dataset.
- Train/test split: 2m50s -> 56s
- K-fold CV: 8m25s -> 2m46s

Let me know if anything needs tweaking or if you'd like further changes. Feel free to merge if you find it useful!